### PR TITLE
Add new and old state summary logs

### DIFF
--- a/src/synchronizers/synchronizeApplications.ts
+++ b/src/synchronizers/synchronizeApplications.ts
@@ -39,6 +39,7 @@ export default async function synchronizeApplications(
   const {
     instance,
     instance: { config },
+    logger,
     graph,
     persister,
   } = executionContext;
@@ -113,6 +114,26 @@ export default async function synchronizeApplications(
     graph.findRelationshipsByType(APPLICATION_USER_RELATIONSHIP_TYPE),
     graph.findRelationshipsByType(USER_IAM_ROLE_RELATIONSHIP_TYPE),
   ]);
+
+  logger.info(
+    {
+      newApplications: newApplications.length,
+      oldApplications: oldApplications.length,
+      newAccountApplicationRelationships:
+        newAccountApplicationRelationships.length,
+      oldAccountApplicationRelationships:
+        oldAccountApplicationRelationships.length,
+      newApplicationGroupAndGroupRoleRelationships:
+        newApplicationGroupAndGroupRoleRelationships.length,
+      oldApplicationGroupRelationships: oldApplicationGroupRelationships.length,
+      oldGroupIAMRoleRelationships: oldGroupIAMRoleRelationships.length,
+      newApplicationUserAndUserRoleRelationships:
+        newApplicationUserAndUserRoleRelationships.length,
+      oldApplicationUserRelationships: oldApplicationUserRelationships.length,
+      oldUserIAMRoleRelationships: oldUserIAMRoleRelationships.length,
+    },
+    "Synchronizing applications...",
+  );
 
   return {
     operations: await persister.publishPersisterOperations([

--- a/src/synchronizers/synchronizeGroups.ts
+++ b/src/synchronizers/synchronizeGroups.ts
@@ -66,6 +66,18 @@ export default async function synchronizeGroups(
     graph.findRelationshipsByType(ACCOUNT_GROUP_RELATIONSHIP_TYPE),
   ]);
 
+  logger.info(
+    {
+      newOktaManagedUserGroups: newOktaManagedUserGroups.length,
+      oldOktaManagedUserGroups: oldOktaManagedUserGroups.length,
+      oldAppManagedUserGroups: oldAppManagedUserGroups.length,
+      newAppManagedUserGroups: newAppManagedUserGroups.length,
+      oldAccountGroupRelationships: oldAccountGroupRelationships.length,
+      newAccountGroupRelationships: newAccountGroupRelationships.length,
+    },
+    "Synchronizing groups...",
+  );
+
   return {
     operations: await persister.publishPersisterOperations([
       [

--- a/src/synchronizers/synchronizeUsers.ts
+++ b/src/synchronizers/synchronizeUsers.ts
@@ -33,6 +33,7 @@ export default async function synchronizeUsers(
 ): Promise<IntegrationExecutionResult> {
   const {
     instance: { config },
+    logger,
     graph,
     persister,
   } = executionContext;
@@ -82,6 +83,20 @@ export default async function synchronizeUsers(
     graph.findRelationshipsByType(USER_MFA_DEVICE_RELATIONSHIP_TYPE),
     graph.findRelationshipsByType(GROUP_USER_RELATIONSHIP_TYPE),
   ]);
+
+  logger.info(
+    {
+      newUsers: newUsers.length,
+      newMFADevices: newMFADevices.length,
+      newUserMFADeviceRelationships: newUserMFADeviceRelationships.length,
+      newGroupUserRelationships: newGroupUserRelationships.length,
+      oldUsers: oldUsers.length,
+      oldMFADevices: oldMFADevices.length,
+      oldUserMFADeviceRelationships: oldUserMFADeviceRelationships.length,
+      oldGroupUserRelationships: oldGroupUserRelationships.length,
+    },
+    "Synchronizing users...",
+  );
 
   return {
     operations: await persister.publishPersisterOperations([


### PR DESCRIPTION
Adding summary logs for resources to process.

It will be good for the persister/synchronizer service to include summaries, to help with knowing the counts of entities/relationships. It will also be important to have the provider clients logging the counts they see on the provider side.