### PR TITLE
Update SDK to fix missing users, add logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/jupiter-managed-integration-sdk": "^32.0.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "^32.0.2",
     "@okta/okta-sdk-nodejs": "^2.0.0",
     "lodash.startcase": "^4.4.0",
     "promise-retry": "^1.1.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ function fetchResourceWith(
   };
 }
 
-const invocationConfig: IntegrationInvocationConfig = {
+export const stepFunctionsInvocationConfig: IntegrationInvocationConfig = {
   instanceConfigFields: {
     oktaOrgUrl: {
       type: "string",
@@ -136,5 +136,3 @@ const invocationConfig: IntegrationInvocationConfig = {
     },
   ],
 };
-
-export default invocationConfig;

--- a/src/okta/types/cache.ts
+++ b/src/okta/types/cache.ts
@@ -33,5 +33,15 @@ export interface OktaApplicationUserCacheEntry {
 }
 
 export interface OktaCacheState {
+  /**
+   * Number of resources seen from resource API.
+   */
+  seen: number;
+
+  /**
+   * Number of keys reported by `cache.putEntries()`.
+   */
+  putEntriesKeys: number;
+
   fetchCompleted: boolean;
 }

--- a/src/synchronizers/synchronizeUsers.ts
+++ b/src/synchronizers/synchronizeUsers.ts
@@ -52,7 +52,7 @@ export default async function synchronizeUsers(
   const newUserMFADeviceRelationships: StandardizedOktaUserFactorRelationship[] = [];
   const newGroupUserRelationships: StandardizedOktaUserGroupRelationship[] = [];
 
-  usersCache.forEach(({ entry }) => {
+  await usersCache.forEach(({ entry }) => {
     const userEntity = createUserEntity(config, entry.data!.user);
     newUsers.push(userEntity);
 

--- a/tools/execute.ts
+++ b/tools/execute.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-console */
 import { executeIntegrationLocal } from "@jupiterone/jupiter-managed-integration-sdk";
-import invocationConfig from "../src/index";
+import { stepFunctionsInvocationConfig } from "../src/index";
 
 const integrationConfig = {
   oktaApiKey: process.env.OKTA_LOCAL_EXECUTION_API_KEY,
@@ -13,7 +13,7 @@ const invocationArgs = {
 
 executeIntegrationLocal(
   integrationConfig,
-  invocationConfig,
+  stepFunctionsInvocationConfig,
   invocationArgs,
 ).catch(err => {
   console.error(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,10 +839,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@jupiterone/jupiter-managed-integration-sdk@^32.0.0":
-  version "32.0.0"
-  resolved "https://registry.npmjs.org/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-32.0.0.tgz#0160c8adf99280af2d72b96f74043db77b703a61"
-  integrity sha512-a5M+u7+pgpRV4+V+WcdJGHi2acuyT12hEOu7ipnN26Ni3Y25x++nilVjGdAv7OrZ70sYuygeVuS3Cbyn4mDABQ==
+"@jupiterone/jupiter-managed-integration-sdk@^32.0.2":
+  version "32.0.2"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-32.0.2.tgz#1e66d559cff779c842df8a9e3f3c77fc8c631b6e"
+  integrity sha512-Eid/ARE/CUzq96es5hqMJ8MH2VW/kfTRI+PtaD8eWy8K3FuyUBPRize6LsgndI4GpaIi/jKWVtdkl45sX5Z3RQ==
 
 "@okta/okta-sdk-nodejs@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
The problem with missing users was due to a bug in the SDK. The `forEach` function would not iterate all the cached users. This adds some trace logging that was instrumental in hunting down the problem. Speaking of trace logging, it would be nice to be able to turn on trace logging depending on the accountId or integration instance ID.