### PR TITLE
106 stop throwing dependency errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - Retry all API errors including `ECONNRESET`
+- Return `IntegrationError` instead of throwing when step dependencies fail
 
 ## 1.7.2 - 2020-11-06
 

--- a/src/synchronizers/synchronizeApplications.ts
+++ b/src/synchronizers/synchronizeApplications.ts
@@ -52,11 +52,13 @@ export default async function synchronizeApplications(
   >("applications");
   const applicationsState = await applicationsCache.getState();
   if (!applicationsState || !applicationsState.fetchCompleted) {
-    throw new IntegrationError({
-      message:
-        "Step 'Applications' dependency failed, cannot ingest application users: 'fetch-applications'",
-      expose: true,
-    });
+    return {
+      error: new IntegrationError({
+        message:
+          "Step 'Applications' dependency failed, cannot ingest application users: 'fetch-applications'",
+        expose: true,
+      }),
+    };
   }
 
   const applicationUsersCache = cache.iterableCache<
@@ -65,11 +67,13 @@ export default async function synchronizeApplications(
   >("application_users");
   const applicationUsersState = await applicationUsersCache.getState();
   if (!applicationUsersState || !applicationUsersState.fetchCompleted) {
-    throw new IntegrationError({
-      message:
-        "Step 'Applications' dependency failed, cannot ingest application users: 'fetch-application-users'",
-      expose: true,
-    });
+    return {
+      error: new IntegrationError({
+        message:
+          "Step 'Applications' dependency failed, cannot ingest application users: 'fetch-application-users'",
+        expose: true,
+      }),
+    };
   }
 
   if (

--- a/src/synchronizers/synchronizeUsers.ts
+++ b/src/synchronizers/synchronizeUsers.ts
@@ -45,11 +45,13 @@ export default async function synchronizeUsers(
 
   const usersState = await usersCache.getState();
   if (!usersState || !usersState.fetchCompleted) {
-    throw new IntegrationError({
-      message:
-        "Step 'Users' dependency failed, cannot ingest application users: 'fetch-users'",
-      expose: true,
-    });
+    return {
+      error: new IntegrationError({
+        message:
+          "Step 'Users' dependency failed, cannot ingest application users: 'fetch-users'",
+        expose: true,
+      }),
+    };
   }
 
   if (usersState.encounteredAuthorizationError) {


### PR DESCRIPTION
Fixes #106 

I'd love for @aiwilliams or @fomentia to review and let me know if the managed sdk will expose these errors to the user if returned in the `error` field. 