### PR TITLE
Add trace-level logs to client calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 1.7.4 - 2020-11-11
+
+- Add warn/trace level logging to client calls
+
 ## 1.7.3 - 2020-11-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-okta",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "A JupiterOne managed integration for https://www.okta.com",
   "main": "dist/index.js",
   "repository": "https://github.com/jupiterone/graph-okta",

--- a/src/okta/createOktaClient.ts
+++ b/src/okta/createOktaClient.ts
@@ -47,19 +47,14 @@ export default function createOktaClient(
   defaultRequestExecutor.on("request", (request: any) => {
     logger.trace(
       {
-        request,
+        url: request.url,
       },
       "Okta client initiated request",
     );
   });
 
   defaultRequestExecutor.on("response", (response: any) => {
-    logger.trace(
-      {
-        response,
-      },
-      "Okta client received response",
-    );
+    logger.trace("Okta client received response");
   });
 
   return new okta.Client({

--- a/src/okta/createOktaClient.ts
+++ b/src/okta/createOktaClient.ts
@@ -44,10 +44,29 @@ export default function createOktaClient(
     );
   });
 
+  defaultRequestExecutor.on("request", (request: any) => {
+    logger.trace(
+      {
+        request,
+      },
+      "Okta client initiated request",
+    );
+  });
+
+  defaultRequestExecutor.on("response", (response: any) => {
+    logger.trace(
+      {
+        response,
+      },
+      "Okta client received response",
+    );
+  });
+
   return new okta.Client({
     orgUrl,
     token,
     requestExecutor: defaultRequestExecutor,
+    // is this necessary? We're not re-calling the same APIs.
     cacheStore: new MemoryStore({
       keyLimit: 100000,
       expirationPoll: null,


### PR DESCRIPTION
Still missing a lot of information about what is happening in these client calls. Adding some trace-level logs to improve visibility in debugging.