### PR TITLE
Fix documentation for group assigned application

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -133,18 +133,18 @@ The following entities are created:
 
 The following relationships are created/mapped:
 
-| Source Entity `_type` | Relationship `_class` | Target Entity `_type` |
-| --------------------- | --------------------- | --------------------- |
-| `okta_account`        | **HAS**               | `okta_application`    |
-| `okta_account`        | **HAS**               | `okta_user_group`     |
-| `okta_account`        | **HAS**               | `okta_service`        |
-| `okta_account`        | **HAS**               | `okta_user`           |
-| `okta_group`          | **ASSIGNED**          | `okta_application`    |
-| `okta_user_group`     | **HAS**               | `okta_user`           |
-| `okta_user`           | **ASSIGNED**          | `okta_application`    |
-| `okta_user`           | **ASSIGNED**          | `aws_iam_role`        |
-| `okta_user`           | **ASSIGNED**          | `mfa_device`          |
-| `okta_user_group`     | **ASSIGNED**          | `aws_iam_role`        |
+| Source Entity `_type`                  | Relationship `_class` | Target Entity `_type` |
+| -------------------------------------- | --------------------- | --------------------- |
+| `okta_account`                         | **HAS**               | `okta_application`    |
+| `okta_account`                         | **HAS**               | `okta_user_group`     |
+| `okta_account`                         | **HAS**               | `okta_service`        |
+| `okta_account`                         | **HAS**               | `okta_user`           |
+| `okta_user_group, okta_app_user_group` | **ASSIGNED**          | `okta_application`    |
+| `okta_user_group`                      | **HAS**               | `okta_user`           |
+| `okta_user`                            | **ASSIGNED**          | `okta_application`    |
+| `okta_user`                            | **ASSIGNED**          | `aws_iam_role`        |
+| `okta_user`                            | **ASSIGNED**          | `mfa_device`          |
+| `okta_user_group`                      | **ASSIGNED**          | `aws_iam_role`        |
 
 <!--
 ********************************************************************************

--- a/src/converters/application.ts
+++ b/src/converters/application.ts
@@ -128,12 +128,19 @@ export function createApplicationGroupRelationships(
   const relationships: Relationship[] = [];
 
   const relationship: Relationship = createDirectRelationship({
-    _class: RelationshipClass.ASSIGNED,
+    _class: Relationships.GROUP_ASSIGNED_APPLICATION._class,
     fromKey: group.id,
+    // Actually okta_user_group or okta_app_user_group.
+    // See `createUserGroupEntity`.
     fromType: 'okta_group',
     toKey: application._key,
     toType: application._type,
     properties: {
+      // Override generated values for _key, _type to maintain
+      // values before migration to new SDK
+      _key: `${group.id}|assigned|${application._key}`,
+      _type: Relationships.GROUP_ASSIGNED_APPLICATION._type,
+
       applicationId: application.id,
       groupId: group.id,
       // Array property not supported on the edge in Neptune

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -119,7 +119,7 @@ export const Relationships: Record<
   GROUP_ASSIGNED_APPLICATION: {
     _type: 'okta_group_assigned_application',
     _class: RelationshipClass.ASSIGNED,
-    sourceType: 'okta_group', // TODO what up with this?
+    sourceType: 'okta_user_group, okta_app_user_group',
     targetType: Entities.APPLICATION._type,
   },
   USER_ASSIGNED_APPLICATION: {


### PR DESCRIPTION
I've reviewed the original code and found that the generated relationship data would be the same. These changes ensure that the `_key` and `_type` are the same (not depending on the way the `createDirectRelationship` generates those using the `from*` and `to*` arguments) and updates the documentation to be more correct.