### PR TITLE
Try-catch and test for non-existent user causing 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ### Fixed
 
+- Fix duplicate relationship error for USER_ASSIGNED_AWS_IAM_ROLE when multiple
+  apps point to the same IAM role.
+
+- Fix 404 error on non-existent user when fetching devices for users.
+
 - Fix `applications` step failure on `MISSING_KEY_ERROR` when group not found
   building relationship to application.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -97,7 +97,15 @@ export class APIClient {
     userId: string,
     iteratee: ResourceIteratee<OktaFactor>,
   ): Promise<void> {
-    await this.oktaClient.listFactors(userId).each(iteratee);
+    try {
+      await this.oktaClient.listFactors(userId).each(iteratee);
+    } catch (err) {
+      if (err.status === 404) {
+        //ignore it. It's probably a user that got deleted between steps
+      } else {
+        throw err;
+      }
+    }
   }
 
   /**

--- a/src/steps/__recordings__/callfakeuser_296306811/recording.har
+++ b/src/steps/__recordings__/callfakeuser_296306811/recording.har
@@ -1,0 +1,186 @@
+{
+  "log": {
+    "_recordingName": "callfakeuser",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "6b2eca4d527e749714739ddcdceeefb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@okta/okta-sdk-nodejs/4.5.1 node/14.17.3 linux/4.4.0-19041-Microsoft"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "dev-857255.okta.com"
+            }
+          ],
+          "headersSize": 316,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://dev-857255.okta.com/api/v1/users/thisisafakekey/factors"
+        },
+        "response": {
+          "bodySize": 294,
+          "content": {
+            "mimeType": "application/json",
+            "size": 294,
+            "text": "{\"errorCode\":\"E0000007\",\"errorSummary\":\"Not found: Resource not found: thisisafakekey (User)\",\"errorLink\":\"E0000007\",\"errorId\":\"oaetx9gVpKDSpSDxcwtKPzzLg\",\"errorCauses\":[]}"
+          },
+          "cookies": [
+            {
+              "expires": "1970-01-01T00:00:10.000Z",
+              "name": "sid",
+              "path": "/",
+              "value": "[REDACTED]"
+            },
+            {
+              "httpOnly": true,
+              "name": "JSESSIONID",
+              "path": "/",
+              "secure": true,
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 23 Jul 2021 15:17:58 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "public-key-pins-report-only",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-okta-request-id",
+              "value": "YPrdpmdsvMZUIRc69aXKgAAACsk"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "p3p",
+              "value": "CP=\"HONK\""
+            },
+            {
+              "name": "x-rate-limit-limit",
+              "value": "600"
+            },
+            {
+              "name": "x-rate-limit-remaining",
+              "value": "599"
+            },
+            {
+              "name": "x-rate-limit-reset",
+              "value": "1627053538"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self' dev-857255.okta.com *.oktacdn.com; connect-src 'self' dev-857255.okta.com dev-857255-admin.okta.com *.oktacdn.com *.mixpanel.com *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com https://oinmanager.okta.com data:; script-src 'unsafe-inline' 'unsafe-eval' 'self' dev-857255.okta.com *.oktacdn.com; style-src 'unsafe-inline' 'self' dev-857255.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com; frame-src 'self' dev-857255.okta.com dev-857255-admin.okta.com login.okta.com; img-src 'self' dev-857255.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com data: blob:; font-src 'self' dev-857255.okta.com data: *.oktacdn.com fonts.gstatic.com"
+            },
+            {
+              "name": "expect-ct",
+              "value": "report-uri=\"https://oktaexpectct.report-uri.com/r/t/ct/reportOnly\", max-age=0"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=315360000; includeSubDomains"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headersSize": 1971,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2021-07-23T15:17:58.596Z",
+        "time": 322,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 322
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/devices.ts
+++ b/src/steps/devices.ts
@@ -27,12 +27,10 @@ export async function fetchDevices({
           userEntity._key,
           async (device) => {
             const deviceEntity = createMFADeviceEntity(device);
-            await jobState.addEntity(createMFADeviceEntity(device));
-
+            await jobState.addEntity(deviceEntity);
             if (device.status === 'ACTIVE') {
               userEntity.mfaEnabled = true;
             }
-
             await jobState.addRelationship(
               createUserMfaDeviceRelationship(userEntity, deviceEntity),
             );

--- a/src/steps/index.test.ts
+++ b/src/steps/index.test.ts
@@ -10,9 +10,9 @@ import { fetchGroups } from './groups';
 import { fetchDevices } from './devices';
 import { fetchApplications } from './applications';
 import { fetchAccountDetails } from './account';
-
-import { integrationConfig } from '../../test/config';
 import { fetchRules } from './rules';
+import { integrationConfig } from '../../test/config';
+import { createAPIClient } from '../client';
 
 jest.setTimeout(1000 * 60 * 1);
 let recording: Recording;
@@ -161,4 +161,24 @@ test('should collect data', async () => {
       required: ['name', 'ruleType', 'status'],
     },
   });
+});
+
+test('call for devices on a fake user', async () => {
+  recording = setupOktaRecording({
+    directory: __dirname,
+    name: 'callfakeuser',
+  });
+
+  const context = createMockStepExecutionContext<IntegrationConfig>({
+    instanceConfig: integrationConfig,
+  });
+
+  const apiClient = createAPIClient(context.instance.config, context.logger);
+  //call a fake user to test failure
+  //the 404 error should be suppressed
+  expect(
+    await apiClient.iterateDevicesForUser('thisisafakekey', () => {
+      jest.fn;
+    }),
+  ).toReturn;
 });


### PR DESCRIPTION
Hi @aiwilliams !

Here is a try-catch and test for handling non-existent users on the devices call. As you said, we can abstract this later for any API call that passes in an object key, such as `listGroupUsers(group.id)`, `.listApplicationGroupAssignments(app.id)`, and `.listApplicationUsers(app.id)`. Those are all in `client.ts`.

--Kevin

