### PR TITLE
Updates for retrieving App creation events from System Logs

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -99,6 +99,16 @@ This allows you to find non-interactive users with a query like
 Find User that !is Person
 ```
 
+For the following relationship:
+
+| `okta_user` | **CREATED** | `okta_application` |
+
+we are using information found in Okta's System Logs. As a result, we are
+limited to the last 90 days available at time of execution. This limits how far
+back the integration can view this particular data, however this relationship is
+set up so that it will not delete any existing relationships when the creation
+event is no longer available in System Logs.
+
 ## Okta API Rate Limits
 
 [Okta API rate limits][2] are sophisticated, depending on a number of factors

--- a/src/okta/types/client.ts
+++ b/src/okta/types/client.ts
@@ -38,6 +38,7 @@ export interface OktaQueryParams {
   filter?: string;
   format?: string;
   search?: string;
+  since?: string;
   expand?: string;
 }
 

--- a/src/steps/__recordings__/steps_741716276/recording.har
+++ b/src/steps/__recordings__/steps_741716276/recording.har
@@ -5176,7 +5176,7 @@
         }
       },
       {
-        "_id": "6853d41f222e237b4525080ec0b22f44",
+        "_id": "8fe1d6a5a50f840d53b21a0ef091f057",
         "_order": 0,
         "cache": {},
         "request": {
@@ -5213,23 +5213,27 @@
               "value": "dev-857255.okta.com"
             }
           ],
-          "headersSize": 398,
+          "headersSize": 433,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
             {
               "name": "filter",
               "value": "eventType eq \"application.lifecycle.update\" and debugContext.debugData.requestUri ew \"_new_\""
+            },
+            {
+              "name": "since",
+              "value": "2022-05-29T00:00:00.000Z"
             }
           ],
-          "url": "https://dev-857255.okta.com/api/v1/logs?filter=eventType%20eq%20%22application.lifecycle.update%22%20and%20debugContext.debugData.requestUri%20ew%20%22_new_%22"
+          "url": "https://dev-857255.okta.com/api/v1/logs?filter=eventType%20eq%20%22application.lifecycle.update%22%20and%20debugContext.debugData.requestUri%20ew%20%22_new_%22&since=2022-05-29T00%3A00%3A00.000Z"
         },
         "response": {
-          "bodySize": 2250,
+          "bodySize": 2874,
           "content": {
             "mimeType": "application/json",
-            "size": 2250,
-            "text": "[{\"actor\":{\"id\":\"00u6b1uy23BmWEf6B4x7\",\"type\":\"User\",\"alternateId\":\"adam.pierson@jupiterone.com\",\"displayName\":\"Adam Pierson\",\"detailEntry\":null},\"client\":{\"userAgent\":{\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36\",\"os\":\"Mac OS X\",\"browser\":\"CHROME\"},\"zone\":\"null\",\"device\":\"Computer\",\"id\":null,\"ipAddress\":\"98.164.7.212\",\"geographicalContext\":{\"city\":\"Wichita\",\"state\":\"Kansas\",\"country\":\"United States\",\"postalCode\":\"67209\",\"geolocation\":{\"lat\":37.6789,\"lon\":-97.4269}}},\"device\":null,\"authenticationContext\":{\"authenticationProvider\":null,\"credentialProvider\":null,\"credentialType\":null,\"issuer\":null,\"interface\":null,\"authenticationStep\":0,\"externalSessionId\":\"102iUMG7iFeQFeyfj48kaO6pw\"},\"displayMessage\":\"Update application\",\"eventType\":\"application.lifecycle.update\",\"outcome\":{\"result\":\"SUCCESS\",\"reason\":null},\"published\":\"2022-07-26T15:42:28.342Z\",\"securityContext\":{\"asNumber\":22773,\"asOrg\":\"cox communications\",\"isp\":\"cox communications inc.\",\"domain\":\"cox.net\",\"isProxy\":false},\"severity\":\"INFO\",\"debugContext\":{\"debugData\":{\"requestId\":\"YuALY03wyyzE8vlszCA5jwAACvI\",\"dtHash\":\"acbe77f599493f60651a3c1bece162cd1341ce8228dbcaa00e1d110811624440\",\"requestUri\":\"/admin/app/sentry/instance/_new_\",\"url\":\"/admin/app/sentry/instance/_new_?\"}},\"legacyEventType\":\"app.generic.config.app_updated\",\"transaction\":{\"type\":\"WEB\",\"id\":\"YuALY03wyyzE8vlszCA5jwAACvI\",\"detail\":{}},\"uuid\":\"8dc7ba43-0cf9-11ed-aff0-e18fe752970e\",\"version\":\"0\",\"request\":{\"ipChain\":[{\"ip\":\"98.164.7.212\",\"geographicalContext\":{\"city\":\"Wichita\",\"state\":\"Kansas\",\"country\":\"United States\",\"postalCode\":\"67209\",\"geolocation\":{\"lat\":37.6789,\"lon\":-97.4269}},\"version\":\"V4\",\"source\":null}]},\"target\":[{\"id\":\"0oa8d47c0zpYd5l9P4x7\",\"type\":\"AppInstance\",\"alternateId\":\"Sentry\",\"displayName\":\"Sentry\",\"detailEntry\":null}]},{\"actor\":{\"id\":\"00u6b1uy23BmWEf6B4x7\",\"type\":\"User\",\"alternateId\":\"adam.pierson@jupiterone.com\",\"displayName\":\"Adam Pierson\",\"detailEntry\":null},\"client\":{\"userAgent\":{\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36\",\"os\":\"Mac OS X\",\"browser\":\"CHROME\"},\"zone\":\"null\",\"device\":\"Computer\",\"id\":null,\"ipAddress\":\"98.164.7.212\",\"geographicalContext\":{\"city\":\"Wichita\",\"state\":\"Kansas\",\"country\":\"United States\",\"postalCode\":\"67209\",\"geolocation\":{\"lat\":37.6789,\"lon\":-97.4269}}},\"device\":null,\"authenticationContext\":{\"authenticationProvider\":null,\"credentialProvider\":null,\"credentialType\":null,\"issuer\":null,\"interface\":null,\"authenticationStep\":0,\"externalSessionId\":\"102-4bpLQSNS_eNMyIpyDCk0A\"},\"displayMessage\":\"Update application\",\"eventType\":\"application.lifecycle.update\",\"outcome\":{\"result\":\"SUCCESS\",\"reason\":null},\"published\":\"2022-07-26T19:07:33.594Z\",\"securityContext\":{\"asNumber\":22773,\"asOrg\":\"cox communications\",\"isp\":\"cox communications inc.\",\"domain\":\"cox.net\",\"isProxy\":false},\"severity\":\"INFO\",\"debugContext\":{\"debugData\":{\"requestId\":\"YuA7dazcAGtU09OPUF3_ggAADAs\",\"dtHash\":\"acbe77f599493f60651a3c1bece162cd1341ce8228dbcaa00e1d110811624440\",\"requestUri\":\"/admin/app/sentry/instance/_new_\",\"url\":\"/admin/app/sentry/instance/_new_?\"}},\"legacyEventType\":\"app.generic.config.app_updated\",\"transaction\":{\"type\":\"WEB\",\"id\":\"YuA7dazcAGtU09OPUF3_ggAADAs\",\"detail\":{}},\"uuid\":\"34482c7a-0d16-11ed-ae1b-39d0c0b4dfc8\",\"version\":\"0\",\"request\":{\"ipChain\":[{\"ip\":\"98.164.7.212\",\"geographicalContext\":{\"city\":\"Wichita\",\"state\":\"Kansas\",\"country\":\"United States\",\"postalCode\":\"67209\",\"geolocation\":{\"lat\":37.6789,\"lon\":-97.4269}},\"version\":\"V4\",\"source\":null}]},\"target\":[{\"id\":\"0oa8d9h1xixM4BkSv4x7\",\"type\":\"AppInstance\",\"alternateId\":\"SentryTest\",\"displayName\":\"Sentry\",\"detailEntry\":null}]}]"
+            "size": 2874,
+            "text": "[{\"actor\":{\"id\":\"00us5ty22kvu4NAxo4x6\",\"type\":\"User\",\"alternateId\":\"austin.kelleher@jupiterone.com\",\"displayName\":\"Austin Kelleher\",\"detailEntry\":null},\"client\":{\"userAgent\":{\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.115 Safari/537.36\",\"os\":\"Mac OS X\",\"browser\":\"CHROME\"},\"zone\":\"null\",\"device\":\"Computer\",\"id\":null,\"ipAddress\":\"136.56.2.241\",\"geographicalContext\":{\"city\":\"Raleigh\",\"state\":\"North Carolina\",\"country\":\"United States\",\"postalCode\":\"27607\",\"geolocation\":{\"lat\":35.797,\"lon\":-78.6865}}},\"device\":null,\"authenticationContext\":{\"authenticationProvider\":null,\"credentialProvider\":null,\"credentialType\":null,\"issuer\":null,\"interface\":null,\"authenticationStep\":0,\"externalSessionId\":\"102IpY-x4JNQCqoTkhj_u3n9w\"},\"displayMessage\":\"Update application\",\"eventType\":\"application.lifecycle.update\",\"outcome\":{\"result\":\"SUCCESS\",\"reason\":null},\"published\":\"2022-06-23T01:05:02.265Z\",\"securityContext\":{\"asNumber\":16591,\"asOrg\":\"google\",\"isp\":\"google fiber inc.\",\"domain\":\"googlefiber.net\",\"isProxy\":false},\"severity\":\"INFO\",\"debugContext\":{\"debugData\":{\"requestId\":\"YrO8PS5MqigrMEXMDEbP5AAADQ0\",\"requestUri\":\"/admin/app/google/instance/_new_\",\"url\":\"/admin/app/google/instance/_new_?\"}},\"legacyEventType\":\"app.generic.config.app_updated\",\"transaction\":{\"type\":\"WEB\",\"id\":\"YrO8PS5MqigrMEXMDEbP5AAADQ0\",\"detail\":{}},\"uuid\":\"82a42325-f290-11ec-b1c2-078cc65ecd5e\",\"version\":\"0\",\"request\":{\"ipChain\":[{\"ip\":\"136.56.2.241\",\"geographicalContext\":{\"city\":\"Raleigh\",\"state\":\"North Carolina\",\"country\":\"United States\",\"postalCode\":\"27607\",\"geolocation\":{\"lat\":35.797,\"lon\":-78.6865}},\"version\":\"V4\",\"source\":null}]},\"target\":[{\"id\":\"0oa7s4dqka0lUpE5W4x7\",\"type\":\"AppInstance\",\"alternateId\":\"jupiterone.dev Google Workspace\",\"displayName\":\"Google Workspace\",\"detailEntry\":null}]},{\"actor\":{\"id\":\"00u6b1uy23BmWEf6B4x7\",\"type\":\"User\",\"alternateId\":\"adam.pierson@jupiterone.com\",\"displayName\":\"Adam Pierson\",\"detailEntry\":null},\"client\":{\"userAgent\":{\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36\",\"os\":\"Mac OS X\",\"browser\":\"CHROME\"},\"zone\":\"null\",\"device\":\"Computer\",\"id\":null,\"ipAddress\":\"98.164.7.212\",\"geographicalContext\":{\"city\":\"Wichita\",\"state\":\"Kansas\",\"country\":\"United States\",\"postalCode\":\"67209\",\"geolocation\":{\"lat\":37.6789,\"lon\":-97.4269}}},\"device\":null,\"authenticationContext\":{\"authenticationProvider\":null,\"credentialProvider\":null,\"credentialType\":null,\"issuer\":null,\"interface\":null,\"authenticationStep\":0,\"externalSessionId\":\"102iUMG7iFeQFeyfj48kaO6pw\"},\"displayMessage\":\"Update application\",\"eventType\":\"application.lifecycle.update\",\"outcome\":{\"result\":\"SUCCESS\",\"reason\":null},\"published\":\"2022-07-26T15:42:28.342Z\",\"securityContext\":{\"asNumber\":22773,\"asOrg\":\"cox communications\",\"isp\":\"cox communications inc.\",\"domain\":\"cox.net\",\"isProxy\":false},\"severity\":\"INFO\",\"debugContext\":{\"debugData\":{\"requestId\":\"YuALY03wyyzE8vlszCA5jwAACvI\",\"dtHash\":\"acbe77f599493f60651a3c1bece162cd1341ce8228dbcaa00e1d110811624440\",\"requestUri\":\"/admin/app/sentry/instance/_new_\",\"url\":\"/admin/app/sentry/instance/_new_?\"}},\"legacyEventType\":\"app.generic.config.app_updated\",\"transaction\":{\"type\":\"WEB\",\"id\":\"YuALY03wyyzE8vlszCA5jwAACvI\",\"detail\":{}},\"uuid\":\"8dc7ba43-0cf9-11ed-aff0-e18fe752970e\",\"version\":\"0\",\"request\":{\"ipChain\":[{\"ip\":\"98.164.7.212\",\"geographicalContext\":{\"city\":\"Wichita\",\"state\":\"Kansas\",\"country\":\"United States\",\"postalCode\":\"67209\",\"geolocation\":{\"lat\":37.6789,\"lon\":-97.4269}},\"version\":\"V4\",\"source\":null}]},\"target\":[{\"id\":\"0oa8d47c0zpYd5l9P4x7\",\"type\":\"AppInstance\",\"alternateId\":\"Sentry\",\"displayName\":\"Sentry\",\"detailEntry\":null}]},{\"actor\":{\"id\":\"00u6b1uy23BmWEf6B4x7\",\"type\":\"User\",\"alternateId\":\"adam.pierson@jupiterone.com\",\"displayName\":\"Adam Pierson\",\"detailEntry\":null},\"client\":{\"userAgent\":{\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36\",\"os\":\"Mac OS X\",\"browser\":\"CHROME\"},\"zone\":\"null\",\"device\":\"Computer\",\"id\":null,\"ipAddress\":\"98.164.7.212\",\"geographicalContext\":{\"city\":\"Wichita\",\"state\":\"Kansas\",\"country\":\"United States\",\"postalCode\":\"67209\",\"geolocation\":{\"lat\":37.6789,\"lon\":-97.4269}}},\"device\":null,\"authenticationContext\":{\"authenticationProvider\":null,\"credentialProvider\":null,\"credentialType\":null,\"issuer\":null,\"interface\":null,\"authenticationStep\":0,\"externalSessionId\":\"102-4bpLQSNS_eNMyIpyDCk0A\"},\"displayMessage\":\"Update application\",\"eventType\":\"application.lifecycle.update\",\"outcome\":{\"result\":\"SUCCESS\",\"reason\":null},\"published\":\"2022-07-26T19:07:33.594Z\",\"securityContext\":{\"asNumber\":22773,\"asOrg\":\"cox communications\",\"isp\":\"cox communications inc.\",\"domain\":\"cox.net\",\"isProxy\":false},\"severity\":\"INFO\",\"debugContext\":{\"debugData\":{\"requestId\":\"YuA7dazcAGtU09OPUF3_ggAADAs\",\"dtHash\":\"acbe77f599493f60651a3c1bece162cd1341ce8228dbcaa00e1d110811624440\",\"requestUri\":\"/admin/app/sentry/instance/_new_\",\"url\":\"/admin/app/sentry/instance/_new_?\"}},\"legacyEventType\":\"app.generic.config.app_updated\",\"transaction\":{\"type\":\"WEB\",\"id\":\"YuA7dazcAGtU09OPUF3_ggAADAs\",\"detail\":{}},\"uuid\":\"34482c7a-0d16-11ed-ae1b-39d0c0b4dfc8\",\"version\":\"0\",\"request\":{\"ipChain\":[{\"ip\":\"98.164.7.212\",\"geographicalContext\":{\"city\":\"Wichita\",\"state\":\"Kansas\",\"country\":\"United States\",\"postalCode\":\"67209\",\"geolocation\":{\"lat\":37.6789,\"lon\":-97.4269}},\"version\":\"V4\",\"source\":null}]},\"target\":[{\"id\":\"0oa8d9h1xixM4BkSv4x7\",\"type\":\"AppInstance\",\"alternateId\":\"SentryTest\",\"displayName\":\"Sentry\",\"detailEntry\":null}]}]"
           },
           "cookies": [
             {
@@ -5255,7 +5259,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Jul 2022 19:53:40 GMT"
+              "value": "Wed, 27 Jul 2022 15:35:30 GMT"
             },
             {
               "name": "content-type",
@@ -5279,7 +5283,7 @@
             },
             {
               "name": "x-okta-request-id",
-              "value": "YuBGQwvoQJDliUHMtwsgdwAAC4A"
+              "value": "YuFbQPmGG2J2lCYWPGBUWAAABHo"
             },
             {
               "name": "x-xss-protection",
@@ -5303,7 +5307,7 @@
             },
             {
               "name": "x-rate-limit-reset",
-              "value": "1658865279"
+              "value": "1658936188"
             },
             {
               "name": "cache-control",
@@ -5323,7 +5327,7 @@
             },
             {
               "name": "link",
-              "value": "<https://dev-857255.okta.com/api/v1/logs?filter=eventType+eq+%22application.lifecycle.update%22+and+debugContext.debugData.requestUri+ew+%22_new_%22>; rel=\"self\", <https://dev-857255.okta.com/api/v1/logs?filter=eventType+eq+%22application.lifecycle.update%22+and+debugContext.debugData.requestUri+ew+%22_new_%22&after=1658862453660_1>; rel=\"next\""
+              "value": "<https://dev-857255.okta.com/api/v1/logs?since=2022-05-29T00%3A00%3A00.000Z&filter=eventType+eq+%22application.lifecycle.update%22+and+debugContext.debugData.requestUri+ew+%22_new_%22>; rel=\"self\", <https://dev-857255.okta.com/api/v1/logs?since=2022-05-29T00%3A00%3A00.000Z&filter=eventType+eq+%22application.lifecycle.update%22+and+debugContext.debugData.requestUri+ew+%22_new_%22&after=1658862453660_1>; rel=\"next\""
             },
             {
               "name": "x-content-type-options",
@@ -5349,14 +5353,14 @@
               "value": "[REDACTED]"
             }
           ],
-          "headersSize": 2433,
+          "headersSize": 2503,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-07-26T19:53:37.696Z",
-        "time": 2863,
+        "startedDateTime": "2022-07-27T15:35:28.310Z",
+        "time": 2188,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5364,11 +5368,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2863
+          "wait": 2188
         }
       },
       {
-        "_id": "b273f8171b2a66a7626058c2a4443746",
+        "_id": "1f73afd4337917b3d3da52a55a920cf7",
         "_order": 0,
         "cache": {},
         "request": {
@@ -5405,10 +5409,14 @@
               "value": "dev-857255.okta.com"
             }
           ],
-          "headersSize": 420,
+          "headersSize": 455,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
+            {
+              "name": "since",
+              "value": "2022-05-29T00:00:00.000Z"
+            },
             {
               "name": "filter",
               "value": "eventType eq \"application.lifecycle.update\" and debugContext.debugData.requestUri ew \"_new_\""
@@ -5418,7 +5426,7 @@
               "value": "1658862453660_1"
             }
           ],
-          "url": "https://dev-857255.okta.com/api/v1/logs?filter=eventType%20eq%20%22application.lifecycle.update%22%20and%20debugContext.debugData.requestUri%20ew%20%22_new_%22&after=1658862453660_1"
+          "url": "https://dev-857255.okta.com/api/v1/logs?since=2022-05-29T00%3A00%3A00.000Z&filter=eventType%20eq%20%22application.lifecycle.update%22%20and%20debugContext.debugData.requestUri%20ew%20%22_new_%22&after=1658862453660_1"
         },
         "response": {
           "bodySize": 2,
@@ -5451,7 +5459,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Jul 2022 19:53:41 GMT"
+              "value": "Wed, 27 Jul 2022 15:35:30 GMT"
             },
             {
               "name": "content-type",
@@ -5475,7 +5483,7 @@
             },
             {
               "name": "x-okta-request-id",
-              "value": "YuBGROMmKfoY9-vqrFUoEgAADz0"
+              "value": "YuFbQoFnYAJJP8KtsU7t6wAAAqY"
             },
             {
               "name": "x-xss-protection",
@@ -5499,7 +5507,7 @@
             },
             {
               "name": "x-rate-limit-reset",
-              "value": "1658865279"
+              "value": "1658936188"
             },
             {
               "name": "cache-control",
@@ -5519,7 +5527,7 @@
             },
             {
               "name": "link",
-              "value": "<https://dev-857255.okta.com/api/v1/logs?filter=eventType+eq+%22application.lifecycle.update%22+and+debugContext.debugData.requestUri+ew+%22_new_%22&after=1658862453660_1>; rel=\"self\", <https://dev-857255.okta.com/api/v1/logs?filter=eventType+eq+%22application.lifecycle.update%22+and+debugContext.debugData.requestUri+ew+%22_new_%22&after=1658862453660_1>; rel=\"next\""
+              "value": "<https://dev-857255.okta.com/api/v1/logs?since=2022-05-29T00%3A00%3A00.000Z&filter=eventType+eq+%22application.lifecycle.update%22+and+debugContext.debugData.requestUri+ew+%22_new_%22&after=1658862453660_1>; rel=\"self\", <https://dev-857255.okta.com/api/v1/logs?since=2022-05-29T00%3A00%3A00.000Z&filter=eventType+eq+%22application.lifecycle.update%22+and+debugContext.debugData.requestUri+ew+%22_new_%22&after=1658862453660_1>; rel=\"next\""
             },
             {
               "name": "x-content-type-options",
@@ -5545,14 +5553,14 @@
               "value": "[REDACTED]"
             }
           ],
-          "headersSize": 2399,
+          "headersSize": 2469,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-07-26T19:53:40.584Z",
-        "time": 622,
+        "startedDateTime": "2022-07-27T15:35:30.506Z",
+        "time": 423,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5560,7 +5568,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 622
+          "wait": 423
         }
       }
     ],

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -197,5 +197,6 @@ export const Relationships: Record<
     _class: RelationshipClass.CREATED,
     sourceType: Entities.USER._type,
     targetType: Entities.APPLICATION._type,
+    partial: true,
   },
 };

--- a/src/steps/index.test.ts
+++ b/src/steps/index.test.ts
@@ -18,6 +18,11 @@ import { createAPIClient } from '../client';
 import { fetchRoles } from './roles';
 import { buildUserCreatedApplication } from './applicationCreation';
 
+// Force the same date to allow Polly to save/find the same URL for
+// the below test of buildUserCreatedApplication().  This date can be
+// changed, but please re-run yarn test:env after doing so.
+Date.now = jest.fn(() => new Date(Date.UTC(2022, 7, 27)).valueOf());
+
 jest.setTimeout(1000 * 60 * 1);
 let recording: Recording;
 afterEach(async () => {


### PR DESCRIPTION
- Moving CREATED relationship to partial so it won't get removed when records are dropped from the Okta logs after 90 days.  
- Updating getLogs call to pull the full available 90 days.