### PR TITLE
INT-5828 - Improve error handling around invalid role formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 - Batch process user group relationship data
 - Disable Okta Node.js client caching
 - Batch process application data
+- Batch process device data
+- Improve error handling around invalid role formats
 
 ## 2.3.1 - 2022-10-13
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-okta",
-  "version": "2.3.2-beta.3",
+  "version": "2.3.2-beta.4",
   "description": "A JupiterOne Integration for https://www.okta.com",
   "license": "MPL-2.0",
   "repository": "https://github.com/jupiterone/graph-okta",

--- a/src/steps/applications.ts
+++ b/src/steps/applications.ts
@@ -119,6 +119,24 @@ export async function buildUserApplicationRelationships(
   });
 }
 
+function createOnInvalidRoleFormatFunction(
+  logger: IntegrationLogger,
+  loggedData: any,
+) {
+  return (invalidRole: any) => {
+    logger.info(
+      {
+        ...loggedData,
+        typeInvalidRole: typeof invalidRole,
+        invalidRoleLen: Array.isArray(invalidRole)
+          ? invalidRole.length
+          : undefined,
+      },
+      'Found invalid role',
+    );
+  };
+}
+
 async function createGroupApplicationRelationships({
   appEntity,
   group,
@@ -137,7 +155,14 @@ async function createGroupApplicationRelationships({
 
   if (groupEntity) {
     await jobState.addRelationships(
-      createApplicationGroupRelationships(appEntity, group),
+      createApplicationGroupRelationships(
+        appEntity,
+        group,
+        createOnInvalidRoleFormatFunction(logger, {
+          appId,
+          groupId: group.id,
+        }),
+      ),
     );
   } else {
     logger.warn(
@@ -168,6 +193,10 @@ async function createUserApplicationRelationships({
     const relationships: Relationship[] = createApplicationUserRelationships(
       appEntity,
       user,
+      createOnInvalidRoleFormatFunction(logger, {
+        appId,
+        userId: user.id,
+      }),
     );
 
     // These relationships include both USER_ASSIGNED_APPLICATION and USER_ASSIGNED_AWS_IAM_ROLE


### PR DESCRIPTION
We are sometimes seeing relationships created with a `role` property that is an Array type. Array property values are not currently supported on relationships and this is causing the JupiterOne system to reject with 400.