### PR TITLE
Reduce group users API concurrency from 10 to 4 to reduce throttling

### DIFF
--- a/src/okta/createOktaClient.ts
+++ b/src/okta/createOktaClient.ts
@@ -11,6 +11,7 @@ const DEFAULT_MINIMUM_RATE_LIMIT_REMAINING = 5;
 
 interface RequestExecutorWithEarlyRateLimitingOptions {
   minimumRateLimitRemaining?: number;
+  m;
 }
 
 /**

--- a/src/okta/createOktaClient.ts
+++ b/src/okta/createOktaClient.ts
@@ -11,7 +11,6 @@ const DEFAULT_MINIMUM_RATE_LIMIT_REMAINING = 5;
 
 interface RequestExecutorWithEarlyRateLimitingOptions {
   minimumRateLimitRemaining?: number;
-  m;
 }
 
 /**

--- a/src/steps/groups.ts
+++ b/src/steps/groups.ts
@@ -164,7 +164,13 @@ async function collectUsersForGroupEntities(
       return { groupEntity, users };
     },
     {
-      concurrency: 10,
+      /**
+       * We throttle requests when the x-rate-limit-remaining header drops below
+       * 5. Previously, our concurrency here was 10, which meant that even if a
+       * request was throttled, there could be 9 additional requests coming right
+       * on its tail - which will result in throttling.
+       */
+      concurrency: 4,
     },
   );
 }


### PR DESCRIPTION
Some users are seeing rate limiting on `/api/v1/groups/*` endpoints. We've tracked it down to this concurrency, which is not respecting queueing/existing rate limits.