### PR TITLE
Release 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## Unreleased
 
+## 2.5.2 - 2023-03-09
+
+### Updated
+
+- Reduced concurrency on `/api/v1/groups/<group-id>/users` from 10 to 4 to
+  reduce throttling.
+
 ## 2.5.1 - 2023-02-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-okta",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "A JupiterOne Integration for https://www.okta.com",
   "license": "MPL-2.0",
   "repository": "https://github.com/jupiterone/graph-okta",


### PR DESCRIPTION
## 2.5.2 - 2023-03-09

### Updated

- Reduced concurrency on `/api/v1/groups/<group-id>/users` from 10 to 4 to
  reduce throttling.