### PR TITLE
INT-7440 - Adding required role documentation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ merged into `main`. An administrator of the GitHub project should:
 That's it! Travis will deploy the necessary bits to NPM. Manual deployment is
 possible of course, just be certain to follow the `yarn build` road.
 
-
 ### Required Role
-The required role to perform all fetch operations that this integration includes and according to [this documentation](https://help.okta.com/oie/en-us/Content/Topics/Security/administrators-admin-comparison.htm) is the **Super Administrator** role. Since the logic in ``src/steps/roles.ts`` initially collects the list of users and performs queries to fetch the roles associated with each user through `apiClient.iterateRolesByUser` and you can't get the role from a user with a higher role than yours.
+
+The required role to perform all fetch operations that this integration includes
+and according to
+[this documentation](https://help.okta.com/oie/en-us/Content/Topics/Security/administrators-admin-comparison.htm)
+is the **Super Administrator** role. Since the logic in `src/steps/roles.ts`
+initially collects the list of users and performs queries to fetch the roles
+associated with each user through `apiClient.iterateRolesByUser` and you can't
+get the role from a user with a higher role than yours.

--- a/README.md
+++ b/README.md
@@ -159,3 +159,7 @@ merged into `main`. An administrator of the GitHub project should:
 
 That's it! Travis will deploy the necessary bits to NPM. Manual deployment is
 possible of course, just be certain to follow the `yarn build` road.
+
+
+### Required Role
+The required role to perform all fetch operations that this integration includes and according to [this documentation](https://help.okta.com/oie/en-us/Content/Topics/Security/administrators-admin-comparison.htm) is the **Super Administrator** role. Since the logic in ``src/steps/roles.ts`` initially collects the list of users and performs queries to fetch the roles associated with each user through `apiClient.iterateRolesByUser` and you can't get the role from a user with a higher role than yours.


### PR DESCRIPTION
As I mentioned in the Readme file, the **Super Administrator** is the only role that can perform the fetch operation to get roles assigned to the user. I tried all the roles contained in this [comparison list](https://help.okta.com/oie/en-us/Content/Topics/Security/administrators-admin-comparison.htm) with the same result (I can't fetch the role). You can take a look at the logs below (I used a trial account with the same configuration to prevent exposing our sensitive information in the logs):

yarn run v1.22.19
$ j1-integration collect
TypeScript files detected. Registering ts-node.

Configuration loaded! Running integration...

13:31:49.522Z  INFO Local: Starting execution with config... (compressionEnabled=false)
13:31:49.526Z  INFO Local: Collected metric.
  metric: {
    "name": "disk-usage",
    "value": 32827,
    "unit": "Bytes",
    "timestamp": 1678887109526
  }
13:31:51.686Z  INFO Local: Starting step "Fetch Account Details"... (stepId=fetch-account)
13:31:52.700Z  INFO Local: (stepId=fetch-account)
  Unable to query Okta Support Info due to ERROR:   [OktaApiError: Okta HTTP 403 E0000006 You do not have permission to perform the requested action. ] {
    status: 403,
    errorCode: 'E0000006',
    errorSummary: 'You do not have permission to perform the requested action',
    errorCauses: [],
    errorLink: 'E0000006',
    errorId: 'oaexLm3X1lETIOZbTCsp4ih5w',
    url: 'https://trial-2899789.okta.com/api/v1/org/privacy/oktaSupport',
    headers: Headers {
      [Symbol(map)]: [Object: null prototype] {
        date: [Array],
        'content-type': [Array],
        'transfer-encoding': [Array],
        connection: [Array],
        server: [Array],
        'public-key-pins-report-only': [Array],
        vary: [Array],
        'x-okta-request-id': [Array],
        'x-xss-protection': [Array],
        p3p: [Array],
        'content-security-policy': [Array],
        'x-rate-limit-limit': [Array],
        'x-rate-limit-remaining': [Array],
        'x-rate-limit-reset': [Array],
        'cache-control': [Array],
        pragma: [Array],
        expires: [Array],
        'x-content-type-options': [Array],
        'strict-transport-security': [Array],
        'content-encoding': [Array],
        'set-cookie': [Array]
      }
    }
  }
13:31:52.731Z  INFO Local: Completed step "Fetch Account Details". (stepId=fetch-account)
13:31:52.731Z  INFO Local: Step summary (stepId=fetch-account)
  summary: {"graphObjectTypeSummary":[{"_type":"okta_account","total":1},{"_type":"okta_service","total":2},{"_type":"okta_account_has_service","total":2}]}
13:31:52.736Z  INFO Local: Starting step "Fetch Users"... (stepId=fetch-users)
13:31:52.736Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "fetch-account",
      "cached": "false"
    },
    "value": 1051,
    "timestamp": 1678887112736
  }
13:31:54.676Z  INFO Local: Completed step "Fetch Users". (stepId=fetch-users)
13:31:54.676Z  INFO Local: Step summary (stepId=fetch-users)
  summary: {"graphObjectTypeSummary":[{"_type":"okta_user","total":2},{"_type":"okta_account_has_user","total":2}]}
13:31:54.680Z  INFO Local: Starting step "Fetch Groups"... (stepId=fetch-groups)
13:31:54.681Z  INFO Local: Starting step "Fetch Devices"... (stepId=fetch-devices)
13:31:54.681Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "fetch-users",
      "cached": "false"
    },
    "value": 1945,
    "timestamp": 1678887114681
  }
13:31:55.441Z  INFO Local: Creating group entity (stepId=fetch-groups, groupId=00g4hj80w8bPaxtsR697)
13:31:55.445Z  INFO Local: Creating group entity (stepId=fetch-groups, groupId=00g4f1n20hB0IsKEi697)
13:31:55.445Z  INFO Local: Finished processing groups (stepId=fetch-groups, groupCollectionEndTime=763, totalGroupsCollected=2)
13:31:55.446Z  INFO Local: Completed step "Fetch Groups". (stepId=fetch-groups)
13:31:55.446Z  INFO Local: Step summary (stepId=fetch-groups)
  summary: {"graphObjectTypeSummary":[{"_type":"okta_user_group","total":2},{"_type":"okta_account_has_group","total":2}]}
13:31:55.450Z  INFO Local: Starting step "Create app user group to user relationships"... (stepId=build-app-user-group-users-relationships)
13:31:55.450Z  INFO Local: Starting step "Create user group to user relationships"... (stepId=build-user-group-users-relationships)
13:31:55.451Z  INFO Local: Starting step "Fetch Rules"... (stepId=fetch-rules)
13:31:55.451Z  INFO Local: Starting step "Fetch Roles"... (stepId=fetch-roles)
13:31:55.452Z  INFO Local: Starting step "Fetch Applications"... (stepId=fetch-applications)
13:31:55.452Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "fetch-groups",
      "cached": "false"
    },
    "value": 772,
    "timestamp": 1678887115452
  }
13:31:55.452Z  INFO Local: Starting to build user group relationships (stepId=build-app-user-group-users-relationships, groupEntityType=okta_app_user_group)
13:31:55.452Z  INFO Local: Starting to build user group relationships (stepId=build-user-group-users-relationships, groupEntityType=okta_user_group)
13:31:55.455Z  INFO Local: Completed step "Create app user group to user relationships". (stepId=build-app-user-group-users-relationships)
13:31:55.455Z  INFO Local: Step summary (stepId=build-app-user-group-users-relationships, summary={"graphObjectTypeSummary":[]})
13:31:55.455Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "build-app-user-group-users-relationships",
      "cached": "false"
    },
    "value": 6,
    "timestamp": 1678887115455
  }
13:31:56.247Z  INFO Local: Failed step summary (stepId=fetch-roles, summary={"graphObjectTypeSummary":[]})
13:31:56.269Z  WARN Local: Step "Fetch Roles" failed to complete due to error. Failed to access provider resource. This integration is likely misconfigured or has insufficient permissions required to access the resource. Please ensure your integration's configuration settings are set up correctly. (errorCode="PROVIDER_AUTHORIZATION_ERROR", errorId="931055ad-12c4-4566-9a81-b06454a7ce66", reason="Provider authorization failed at https://trial-2899789.okta.com/api/v1/users/00u4f1q626TiX10vV697/roles: 403 You do not have permission to perform the requested action") (stepId=fetch-roles, errorId=931055ad-12c4-4566-9a81-b06454a7ce66, code=PROVIDER_AUTHORIZATION_ERROR)
  Error: Provider authorization failed at https://trial-2899789.okta.com/api/v1/users/00u4f1q626TiX10vV697/roles: 403 You do not have permission to perform the requested action
      at APIClient.iterateRolesByUser (/Users/jeanroblesguanipa/Documents/j1/code/graph-okta/src/client.ts:316:15)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at /Users/jeanroblesguanipa/Documents/j1/code/graph-okta/src/steps/roles.ts:59:7
      at /Users/jeanroblesguanipa/Documents/j1/code/graph-okta/node_modules/@jupiterone/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/indices.ts:34:7
      at iteratee (/Users/jeanroblesguanipa/Documents/j1/code/graph-okta/node_modules/@jupiterone/integration-sdk-runtime/src/fileSystem.ts:215:7)
      at onFile (/Users/jeanroblesguanipa/Documents/j1/code/graph-okta/node_modules/@jupiterone/integration-sdk-runtime/src/fileSystem.ts:176:5)
      at handleFilePath (/Users/jeanroblesguanipa/Documents/j1/code/graph-okta/node_modules/@jupiterone/integration-sdk-runtime/src/fileSystem.ts:189:7)
      at handleFilePath (/Users/jeanroblesguanipa/Documents/j1/code/graph-okta/node_modules/@jupiterone/integration-sdk-runtime/src/fileSystem.ts:195:7)
      at walkDirectory (/Users/jeanroblesguanipa/Documents/j1/code/graph-okta/node_modules/@jupiterone/integration-sdk-runtime/src/fileSystem.ts:200:5)
      at iterateCollectionTypeIndex (/Users/jeanroblesguanipa/Documents/j1/code/graph-okta/node_modules/@jupiterone/integration-sdk-runtime/src/storage/FileSystemGraphObjectStore/indices.ts:32:3)
  Caused by: OktaApiError: Okta HTTP 403 E0000006 You do not have permission to perform the requested action. 
13:31:56.273Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "fetch-roles",
      "cached": "false"
    },
    "value": 822,
    "timestamp": 1678887116273
  }
13:31:56.309Z  INFO Local: Completed step "Fetch Applications". (stepId=fetch-applications)
13:31:56.309Z  INFO Local: Step summary (stepId=fetch-applications, summary={"graphObjectTypeSummary":[]})
13:31:56.309Z  INFO Local: Starting step "Build User Created Application Relationship"... (stepId=build-application-creation-relationship)
13:31:56.310Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "fetch-applications",
      "cached": "false"
    },
    "value": 859,
    "timestamp": 1678887116310
  }
13:31:56.476Z  INFO Local: Successfully created user group relationship (stepId=build-user-group-users-relationships, groupId=00g4hj80w8bPaxtsR697, userId=00u4hj6viyFz2J7k3697)
13:31:56.476Z  INFO Local: Successfully created user group relationship (stepId=build-user-group-users-relationships, groupId=00g4f1n20hB0IsKEi697, userId=00u4f1q626TiX10vV697)
13:31:56.477Z  INFO Local: Successfully created user group relationship (stepId=build-user-group-users-relationships, groupId=00g4f1n20hB0IsKEi697, userId=00u4hj6viyFz2J7k3697)
13:31:56.477Z  INFO Local: Completed step "Create user group to user relationships". (stepId=build-user-group-users-relationships)
13:31:56.477Z  INFO Local: Step summary (stepId=build-user-group-users-relationships)
  summary: {"graphObjectTypeSummary":[{"_type":"okta_group_has_user","total":3}]}
13:31:56.477Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "build-user-group-users-relationships",
      "cached": "false"
    },
    "value": 1027,
    "timestamp": 1678887116477
  }
13:31:56.479Z  INFO Local: Completed step "Fetch Rules". (stepId=fetch-rules)
13:31:56.479Z  INFO Local: Step summary (stepId=fetch-rules, summary={"graphObjectTypeSummary":[]})
13:31:56.479Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "fetch-rules",
      "cached": "false"
    },
    "value": 1028,
    "timestamp": 1678887116479
  }
13:31:56.509Z  INFO Local: Completed step "Fetch Devices". (stepId=fetch-devices)
13:31:56.509Z  INFO Local: Step summary (stepId=fetch-devices)
  summary: {"graphObjectTypeSummary":[{"_type":"mfa_device","total":6},{"_type":"okta_user_assigned_factor","total":6}]}
13:31:56.512Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "fetch-devices",
      "cached": "false"
    },
    "value": 1831,
    "timestamp": 1678887116512
  }
13:31:57.504Z  INFO Local: Completed step "Build User Created Application Relationship". (stepId=build-application-creation-relationship)
13:31:57.505Z  INFO Local: Step summary (stepId=build-application-creation-relationship, summary={"graphObjectTypeSummary":[]})
13:31:57.505Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-step",
    "unit": "Milliseconds",
    "dimensions": {
      "stepId": "build-application-creation-relationship",
      "cached": "false"
    },
    "value": 1196,
    "timestamp": 1678887117505
  }
13:31:57.508Z  INFO Local: Integration data collection has completed.
  collectionResult: {
    "integrationStepResults": [
      {
        "id": "fetch-account",
        "name": "Fetch Account Details",
        "dependsOn": [],
        "declaredTypes": [
          "okta_account",
          "okta_service",
          "okta_account_has_service"
        ],
        "partialTypes": [],
        "encounteredTypes": [
          "okta_account",
          "okta_service",
          "okta_account_has_service"
        ],
        "status": "success"
      },
      {
        "id": "fetch-users",
        "name": "Fetch Users",
        "dependsOn": [
          "fetch-account"
        ],
        "declaredTypes": [
          "okta_user",
          "okta_account_has_user"
        ],
        "partialTypes": [],
        "encounteredTypes": [
          "okta_user",
          "okta_account_has_user"
        ],
        "status": "success"
      },
      {
        "id": "fetch-groups",
        "name": "Fetch Groups",
        "dependsOn": [
          "fetch-users"
        ],
        "declaredTypes": [
          "okta_user_group",
          "okta_app_user_group",
          "okta_account_has_group",
          "okta_account_has_group"
        ],
        "partialTypes": [],
        "encounteredTypes": [
          "okta_user_group",
          "okta_account_has_group"
        ],
        "status": "success"
      },
      {
        "id": "build-app-user-group-users-relationships",
        "name": "Create app user group to user relationships",
        "dependsOn": [
          "fetch-users",
          "fetch-groups"
        ],
        "declaredTypes": [
          "okta_app_user_group_has_user"
        ],
        "partialTypes": [],
        "encounteredTypes": [],
        "status": "success"
      },
      {
        "id": "build-user-group-users-relationships",
        "name": "Create user group to user relationships",
        "dependsOn": [
          "fetch-users",
          "fetch-groups"
        ],
        "declaredTypes": [
          "okta_group_has_user"
        ],
        "partialTypes": [],
        "encounteredTypes": [
          "okta_group_has_user"
        ],
        "status": "success"
      },
      {
        "id": "fetch-devices",
        "name": "Fetch Devices",
        "dependsOn": [
          "fetch-users"
        ],
        "declaredTypes": [
          "mfa_device",
          "okta_user_assigned_factor"
        ],
        "partialTypes": [],
        "encounteredTypes": [
          "mfa_device",
          "okta_user_assigned_factor"
        ],
        "status": "success"
      },
      {
        "id": "fetch-rules",
        "name": "Fetch Rules",
        "dependsOn": [
          "fetch-users",
          "fetch-groups"
        ],
        "declaredTypes": [
          "okta_rule",
          "okta_account_has_rule",
          "okta_rule_manages_user_group"
        ],
        "partialTypes": [],
        "encounteredTypes": [],
        "status": "success"
      },
      {
        "id": "fetch-roles",
        "name": "Fetch Roles",
        "dependsOn": [
          "fetch-users",
          "fetch-groups"
        ],
        "declaredTypes": [
          "okta_role",
          "okta_user_assigned_role",
          "okta_user_group_assigned_role"
        ],
        "partialTypes": [],
        "encounteredTypes": [],
        "status": "failure"
      },
      {
        "id": "fetch-applications",
        "name": "Fetch Applications",
        "dependsOn": [
          "fetch-groups"
        ],
        "declaredTypes": [
          "okta_application",
          "okta_account_has_application",
          "okta_group_assigned_application",
          "okta_user_assigned_application",
          "okta_user_assigned_aws_iam_role",
          "okta_user_group_assigned_aws_iam_role"
        ],
        "partialTypes": [],
        "encounteredTypes": [],
        "status": "success"
      },
      {
        "id": "build-application-creation-relationship",
        "name": "Build User Created Application Relationship",
        "dependsOn": [
          "fetch-applications",
          "fetch-users"
        ],
        "declaredTypes": [
          "okta_user_created_application"
        ],
        "partialTypes": [
          "okta_user_created_application"
        ],
        "encounteredTypes": [],
        "status": "success"
      }
    ],
    "metadata": {
      "partialDatasets": {
        "types": [
          "okta_role",
          "okta_user_assigned_role",
          "okta_user_group_assigned_role",
          "okta_user_created_application"
        ]
      }
    }
  }
13:31:57.511Z  INFO Local: Collected metric.
  metric: {
    "name": "disk-usage",
    "value": 32827,
    "unit": "Bytes",
    "timestamp": 1678887117511
  }
13:31:57.511Z  INFO Local: Collected metric.
  metric: {
    "name": "duration-collect",
    "unit": "Milliseconds",
    "value": 7989,
    "timestamp": 1678887117511
  }

Results:

Step "fetch-account" completed with status: success
Step "fetch-users" completed with status: success
Step "fetch-groups" completed with status: success
Step "build-app-user-group-users-relationships" completed with status: success
Step "build-user-group-users-relationships" completed with status: success
Step "fetch-devices" completed with status: success
Step "fetch-rules" completed with status: success
Step "fetch-roles" completed with status: failure
Step "fetch-applications" completed with status: success
Step "build-application-creation-relationship" completed with status: success

The following datasets were marked as partial:
  - okta_role
  - okta_user_assigned_role
  - okta_user_group_assigned_role
  - okta_user_created_application
✨  Done in 9.71s.`
`